### PR TITLE
Change of initial estimate of lucy

### DIFF
--- a/src/lucy.jl
+++ b/src/lucy.jl
@@ -28,7 +28,7 @@ function lucy(observed::AbstractArray, psf::AbstractArray; iterations::Integer =
         return e .* real(ifft(fft(observed ./ ifft(fft(e) .* psf_ft)) .* psf_ft_conj)) 
     end
 
-    estimated = observed
+    estimated = real(ifft(fft(observed) .* psf_ft))
     for i in 1:iterations
         estimated = lucystep(estimated)
     end


### PR DESCRIPTION
Hey,

with the current estimate, Lucy Richardson fails to remove the Poisson noise. Actually LR tries to generate details and therefore it won't touch the high frequencies (noise).
Therefore we change the initial estimate to something else namely the measured image convolved with the PSF.

A minimal example to convince yourself, is below. 
You can also see the final image [here](https://felix.sumpi.org/lucy_fails.png). The left one is the current lucy, the right one is the fixed one.



```julia
using FFTW, Noise, Deconvolution, TestImages, Images

function lucy2(observed::AbstractArray, psf::AbstractArray; iterations::Integer = 1)
    @assert size(observed) == size(psf)
    @assert iterations >= 0

    psf_ft = fft(psf)
    psf_ft_conj = conj.(psf_ft)

    function lucystep(e)
        return e .* real(ifft(fft(observed ./ ifft(fft(e) .* psf_ft)) .* psf_ft_conj)) 
    end

    estimated = real(ifft(fft(observed) .* psf_ft))
    for i in 1:iterations
        estimated = lucystep(estimated)
    end

    return estimated
end

img = channelview(testimage("fabio_gray_256"))

x = LinRange(-40, 40, 256)
y = transpose(x)

# create PSF
psf = exp.(- (x.^2 .+ y.^2))
# normalize PSF to 1
psf ./= sum(psf)
psf = ifftshift(psf)

# blur
img_b = real(ifft(fft(img) .* fft(psf)))
# Poisson noise
img_noisy = poisson(img_b, 500)
# current from package
res_lr1 = lucy(img_noisy, psf, iterations=20);
# fixed one
res_lr2 = lucy2(img_noisy, psf, iterations=20);
colorview(Gray, [res_lr1[100:200, 100:200] res_lr2[100:200, 100:200]])
```